### PR TITLE
Add support for Zybo Z7-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Demo of [hdl-util/hdmi](https://github.com/hdl-util/hdmi/) on several boards:
 |---|---|---|---|
 |[Arduino MKR Vidor 4000](https://store.arduino.cc/usa/mkr-vidor-4000)|Intel Cyclone 10 LP (10CL016)|1280x720 @ 59.94Hz|PCM 24-bit 48KHz|
 |[Seeed Spartan Edge Accelerator](https://www.seeedstudio.com/Spartan-Edge-Accelerator-Board-p-4261.html)|Xilinx Spartan 7 (XC7S15)|1280x720 @ 60Hz|PCM 24-bit 48KHz (approximately)|
+|[Digilent Zybo Z7-20](https://digilent.com/shop/zybo-z7-zynq-7000-arm-fpga-soc-development-board/)|Xilinx Zynq-7000 (XC7Z020)|1280x720 @ 60Hz|PCM 24-bit 48KHz (approximately)|

--- a/pll/hdmi_pll_xilinx.v
+++ b/pll/hdmi_pll_xilinx.v
@@ -52,8 +52,7 @@
 //----------------------------------------------------------------------------
 // None
 
-`ifdef USE_125MHZ
-//
+// If using 125MHz clock, add synthesis argument `-verilog_define USE_125MHZ=1`
 //----------------------------------------------------------------------------
 //  Output     Output      Phase    Duty Cycle   Pk-to-Pk     Phase
 //   Clock     Freq (MHz)  (degrees)    (%)     Jitter (ps)  Error (ps)
@@ -65,8 +64,8 @@
 // Input Clock   Freq (MHz)    Input Jitter (UI)
 //----------------------------------------------------------------------------
 // __primary_________125.000____________0.010
-`else // USE_100MHZ
-//
+
+// Default: 100MHz clock source
 //----------------------------------------------------------------------------
 //  Output     Output      Phase    Duty Cycle   Pk-to-Pk     Phase
 //   Clock     Freq (MHz)  (degrees)    (%)     Jitter (ps)  Error (ps)
@@ -78,7 +77,6 @@
 // Input Clock   Freq (MHz)    Input Jitter (UI)
 //----------------------------------------------------------------------------
 // __primary_________100.000____________0.010
-`endif
 
 `timescale 1ps/1ps
 

--- a/pll/hdmi_pll_xilinx.v
+++ b/pll/hdmi_pll_xilinx.v
@@ -51,6 +51,21 @@
 // User entered comments
 //----------------------------------------------------------------------------
 // None
+
+`ifdef USE_125MHZ
+//
+//----------------------------------------------------------------------------
+//  Output     Output      Phase    Duty Cycle   Pk-to-Pk     Phase
+//   Clock     Freq (MHz)  (degrees)    (%)     Jitter (ps)  Error (ps)
+//----------------------------------------------------------------------------
+// clk_out1____74.256______0.000______50.0______239.766____368.066
+// clk_out2___371.280______0.000______50.0______192.979____368.066
+//
+//----------------------------------------------------------------------------
+// Input Clock   Freq (MHz)    Input Jitter (UI)
+//----------------------------------------------------------------------------
+// __primary_________125.000____________0.010
+`else // USE_100MHZ
 //
 //----------------------------------------------------------------------------
 //  Output     Output      Phase    Duty Cycle   Pk-to-Pk     Phase
@@ -63,6 +78,7 @@
 // Input Clock   Freq (MHz)    Input Jitter (UI)
 //----------------------------------------------------------------------------
 // __primary_________100.000____________0.010
+`endif
 
 `timescale 1ps/1ps
 
@@ -124,19 +140,27 @@ wire clk_in2_clk_wiz_0;
     .CLKOUT4_CASCADE      ("FALSE"),
     .COMPENSATION         ("ZHOLD"),
     .STARTUP_WAIT         ("FALSE"),
+`ifdef USE_125MHZ
+    .DIVCLK_DIVIDE        (7),
+    .CLKFBOUT_MULT_F      (62.375),
+    .CLKOUT0_DIVIDE_F     (15.000),
+    .CLKOUT1_DIVIDE       (3),
+    .CLKIN1_PERIOD        (8.000),
+`else // USE_100MHZ
     .DIVCLK_DIVIDE        (5),
     .CLKFBOUT_MULT_F      (37.125),
+    .CLKOUT0_DIVIDE_F     (10.000),
+    .CLKOUT1_DIVIDE       (2),
+    .CLKIN1_PERIOD        (10.000),
+`endif
     .CLKFBOUT_PHASE       (0.000),
     .CLKFBOUT_USE_FINE_PS ("FALSE"),
-    .CLKOUT0_DIVIDE_F     (10.000),
     .CLKOUT0_PHASE        (0.000),
     .CLKOUT0_DUTY_CYCLE   (0.500),
     .CLKOUT0_USE_FINE_PS  ("FALSE"),
-    .CLKOUT1_DIVIDE       (2),
     .CLKOUT1_PHASE        (0.000),
     .CLKOUT1_DUTY_CYCLE   (0.500),
-    .CLKOUT1_USE_FINE_PS  ("FALSE"),
-    .CLKIN1_PERIOD        (10.000))
+    .CLKOUT1_USE_FINE_PS  ("FALSE"))
   mmcm_adv_inst
     // Output clocks
    (

--- a/syn/zybo_z7_20_vivado/Manifest.py
+++ b/syn/zybo_z7_20_vivado/Manifest.py
@@ -1,0 +1,21 @@
+action = "synthesis"
+syn_device = "xc7z020"
+syn_grade = "-1"
+syn_package = "clg400"
+syn_top = "zybo_z7_top"
+syn_project = "zybo_z7_top"
+syn_tool = "vivado"
+syn_properties = [
+  ["steps.synth_design.args.more options", "-verilog_define USE_125MHZ=1 -effort_level quick"],
+  ["steps.synth_design.args.directive", "RunTimeOptimized"],
+  ["steps.opt_design.args.directive", "RuntimeOptimized"],
+  ["steps.place_design.args.directive", "RuntimeOptimized"],
+  ["steps.route_design.args.directive", "RuntimeOptimized"],
+]
+
+modules = {
+  "local" : [
+    "../../top/zybo_z7",
+    "../../pll"
+  ],
+}

--- a/top/zybo_z7/Manifest.py
+++ b/top/zybo_z7/Manifest.py
@@ -1,0 +1,14 @@
+files = [
+    "zybo_z7_top.sv",
+    "pinout.xdc"
+]
+
+modules = {
+    "git": [
+        "git@github.com:hdl-util/hdmi.git::master",
+        "git@github.com:hdl-util/sound.git::master",
+        "git@github.com:hdl-util/vga-text-mode.git::master"
+    ]
+}
+
+fetchto = "../../ip_cores"

--- a/top/zybo_z7/pinout.xdc
+++ b/top/zybo_z7/pinout.xdc
@@ -1,0 +1,33 @@
+set_property CFGBVS VCCO [current_design]
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+
+## TD0-, TD0+
+set_property -dict { PACKAGE_PIN D19   IOSTANDARD TMDS_33     } [get_ports HDMI_TX[0]]
+set_property -dict { PACKAGE_PIN D20   IOSTANDARD TMDS_33     } [get_ports HDMI_TX_N[0]]
+
+## TD1-, TD1+
+set_property -dict { PACKAGE_PIN C20   IOSTANDARD TMDS_33     } [get_ports HDMI_TX[1]]
+set_property -dict { PACKAGE_PIN B20   IOSTANDARD TMDS_33     } [get_ports HDMI_TX_N[1]]
+
+## TD2-, TD2+
+set_property -dict { PACKAGE_PIN B19   IOSTANDARD TMDS_33     } [get_ports HDMI_TX[2]]
+set_property -dict { PACKAGE_PIN A20   IOSTANDARD TMDS_33     } [get_ports HDMI_TX_N[2]]
+
+# TCK-, TCK+
+set_property -dict { PACKAGE_PIN H17   IOSTANDARD TMDS_33     } [get_ports HDMI_CLK_N]
+set_property -dict { PACKAGE_PIN H16   IOSTANDARD TMDS_33     } [get_ports HDMI_CLK]
+
+# CEC, SDA, SCL, DPD_DET
+set_property -dict { PACKAGE_PIN E19   IOSTANDARD LVCMOS33 } [get_ports HDMI_CEC]
+set_property -dict { PACKAGE_PIN G18   IOSTANDARD LVCMOS33 } [get_ports HDMI_SDA]
+set_property -dict { PACKAGE_PIN G17   IOSTANDARD LVCMOS33 } [get_ports HDMI_SCL]
+set_property -dict { PACKAGE_PIN E18   IOSTANDARD LVCMOS33 } [get_ports HDMI_HPD]
+
+
+set_property -dict { PACKAGE_PIN G15   IOSTANDARD LVCMOS33 } [get_ports RESET]
+
+set_property -dict { PACKAGE_PIN K17   IOSTANDARD LVCMOS33 } [get_ports CLK_125MHZ]
+create_clock -add -name CLK_125MHZ -period 8.00 -waveform {0 4} [get_ports CLK_125MHZ]
+
+set_property -dict { PACKAGE_PIN M14   IOSTANDARD LVCMOS33 } [get_ports LED[0]]
+set_property -dict { PACKAGE_PIN M15   IOSTANDARD LVCMOS33 } [get_ports LED[1]]

--- a/top/zybo_z7/zybo_z7_top.sv
+++ b/top/zybo_z7/zybo_z7_top.sv
@@ -1,0 +1,72 @@
+module zybo_z7_top
+(
+  input CLK_125MHZ,
+
+  output [1:0] LED,
+
+  // HDMI output
+  output [2:0] HDMI_TX,
+  output [2:0] HDMI_TX_N,
+  output HDMI_CLK,
+  output HDMI_CLK_N,
+  input HDMI_CEC,
+  inout HDMI_SDA,
+  inout HDMI_SCL,
+  input HDMI_HPD
+);
+
+wire clk_pixel_x5;
+wire clk_pixel;
+wire clk_audio;
+hdmi_pll_xilinx hdmi_pll(.clk_in1(CLK_125MHZ), .clk_out1(clk_pixel), .clk_out2(clk_pixel_x5));
+
+logic [10:0] counter = 1'd0;
+always_ff @(posedge clk_pixel)
+begin
+    counter <= counter == 11'd1546 ? 1'd0 : counter + 1'd1;
+end
+assign clk_audio = clk_pixel && counter == 11'd1546;
+
+localparam AUDIO_BIT_WIDTH = 16;
+localparam AUDIO_RATE = 48000;
+localparam WAVE_RATE = 480;
+
+logic [AUDIO_BIT_WIDTH-1:0] audio_sample_word;
+logic [AUDIO_BIT_WIDTH-1:0] audio_sample_word_dampened; // This is to avoid giving you a heart attack -- it'll be really loud if it uses the full dynamic range.
+assign audio_sample_word_dampened = audio_sample_word >> 9;
+
+sawtooth #(.BIT_WIDTH(AUDIO_BIT_WIDTH), .SAMPLE_RATE(AUDIO_RATE), .WAVE_RATE(WAVE_RATE)) sawtooth (.clk_audio(clk_audio), .level(audio_sample_word));
+
+logic [23:0] rgb;
+logic [9:0] cx, cy;
+logic [2:0] tmds;
+logic tmds_clock;
+hdmi #(.VIDEO_ID_CODE(4), .VIDEO_REFRESH_RATE(60.0), .AUDIO_RATE(AUDIO_RATE), .AUDIO_BIT_WIDTH(AUDIO_BIT_WIDTH)) hdmi(.clk_pixel_x5(clk_pixel_x5), .clk_pixel(clk_pixel), .clk_audio(clk_audio), .rgb(rgb), .audio_sample_word('{audio_sample_word_dampened, audio_sample_word_dampened}), .tmds(tmds), .tmds_clock(tmds_clock), .cx(cx), .cy(cy));
+
+genvar i;
+generate
+    for (i = 0; i < 3; i++)
+    begin: obufds_gen
+        OBUFDS #(.IOSTANDARD("TMDS_33")) obufds (.I(tmds[i]), .O(HDMI_TX[i]), .OB(HDMI_TX_N[i]));
+    end
+    OBUFDS #(.IOSTANDARD("TMDS_33")) obufds_clock(.I(tmds_clock), .O(HDMI_CLK), .OB(HDMI_CLK_N));
+endgenerate
+
+logic [7:0] character = 8'h30;
+logic [5:0] prevcy = 6'd0;
+always @(posedge clk_pixel)
+begin
+    if (cy == 10'd0)
+    begin
+        character <= 8'h30;
+        prevcy <= 6'd0;
+    end
+    else if (prevcy != cy[9:4])
+    begin
+        character <= character + 8'h01;
+        prevcy <= cy[9:4];
+    end
+end
+
+console console(.clk_pixel(clk_pixel), .codepoint(character), .attribute({cx[9], cy[8:6], cx[8:5]}), .cx(cx), .cy(cy), .rgb(rgb));
+endmodule


### PR DESCRIPTION
![zybo_z7_demo](https://user-images.githubusercontent.com/40348686/155118463-9e32bd6a-3309-4c32-a84e-33d7ea32dd48.gif)

Status: Working for Z7-20 variant (at least)
- [x] Use 125 MHz system clock
- [x] 1280x720 60Hz
- [x] 24-bit 48KHz HDMI audio
- [ ] Test other configurations

Demo utilization:
![image](https://user-images.githubusercontent.com/40348686/155122723-eefe9a00-ed88-41d8-b960-901cbcb34081.png)


Z7-10 variant should work with the same pinout.xdc, but I do not have one for testing.