### PR TITLE
Clone git modules over https:// instead of git@

### DIFF
--- a/top/mkrvidor4000/Manifest.py
+++ b/top/mkrvidor4000/Manifest.py
@@ -4,9 +4,9 @@ files = [
 
 modules = {
     "git": [
-        "git@github.com:hdl-util/hdmi.git::master",
-        "git@github.com:hdl-util/sound.git::master",
-        "git@github.com:hdl-util/vga-text-mode.git::master"
+        "https://github.com/hdl-util/hdmi.git::master",
+        "https://github.com/hdl-util/sound.git::master",
+        "https://github.com/hdl-util/vga-text-mode.git::master"
     ]
 }
 

--- a/top/sea/Manifest.py
+++ b/top/sea/Manifest.py
@@ -5,9 +5,9 @@ files = [
 
 modules = {
     "git": [
-        "git@github.com:hdl-util/hdmi.git::master",
-        "git@github.com:hdl-util/sound.git::master",
-        "git@github.com:hdl-util/vga-text-mode.git::master"
+        "https://github.com/hdl-util/hdmi.git::master",
+        "https://github.com/hdl-util/sound.git::master",
+        "https://github.com/hdl-util/vga-text-mode.git::master"
     ]
 }
 

--- a/top/zybo_z7/Manifest.py
+++ b/top/zybo_z7/Manifest.py
@@ -5,9 +5,9 @@ files = [
 
 modules = {
     "git": [
-        "git@github.com:hdl-util/hdmi.git::master",
-        "git@github.com:hdl-util/sound.git::master",
-        "git@github.com:hdl-util/vga-text-mode.git::master"
+        "https://github.com/hdl-util/hdmi.git::master",
+        "https://github.com/hdl-util/sound.git::master",
+        "https://github.com/hdl-util/vga-text-mode.git::master"
     ]
 }
 


### PR DESCRIPTION
This allows users to clone modules without SSH authentication and resolves #3